### PR TITLE
URI-encode polylines

### DIFF
--- a/api/app/src/routes/api/v1/meta.router.js
+++ b/api/app/src/routes/api/v1/meta.router.js
@@ -70,7 +70,7 @@ class MetaRouter {
     const finalGeoJSON = turf_buffer(turf_simplify(largestPolyGeoJSON, tolerance), bufferKm, 'kilometers');
     const finalGeometry = finalGeoJSON.geometry.coordinates[0];
 
-    ctx.body = polyline.encode(finalGeometry);
+    ctx.body = encodeURIComponent(polyline.encode(finalGeometry));
     // var decoded = polyline.decode(polyline.encode(finalGeometry));
     // ctx.body = JSON.stringify({
     //   "type": "Feature",

--- a/api/doc/swagger.yml
+++ b/api/doc/swagger.yml
@@ -262,7 +262,7 @@ paths:
     get:
       tags:
       - "meta"
-      summary: "Gets an encoded polyline for a given country ISO3 code"
+      summary: "Gets an URL-encoded polyline for a given country ISO3 code"
       produces:
       - "application/text"
       parameters:


### PR DESCRIPTION
Polylines from the `country_polyline` endpoint are now URI-encoded, which fixes an issue where the OSMA client would incorrectly parse polylines in URLs.